### PR TITLE
Disable the default Panther lora-pkt-fwd.service

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -46,7 +46,9 @@ if id -nG admin | grep -qw "sudo"; then
        systemctl enable $name.timer
        systemctl start $name.service
     done
-
+    
+    systemctl disable lora-pkt-fwd.service
+    
     systemctl start install-dashboard.service
 
     echo 'Success.'


### PR DESCRIPTION
This sometimes fails at boot without a timer delay, I've committed a lora-pkt-fwd.timer to systemd to correct this.